### PR TITLE
Fix link component to add rel attribute for _blank targets

### DIFF
--- a/app/_components/elements/link/link.tsx
+++ b/app/_components/elements/link/link.tsx
@@ -7,8 +7,9 @@ type Props = {
 };
 
 export const Link = ({ href, children, target = "_self", ...props }: Props) => {
+  const rel = target === "_blank" ? "noopener noreferrer" : undefined;
   return (
-    <NextLink href={href} target={target} {...props}>
+    <NextLink href={href} target={target} rel={rel} {...props}>
       {children}
     </NextLink>
   );


### PR DESCRIPTION
## Summary
- ensure Link component adds `rel="noopener noreferrer"` when using `target="_blank"`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_685219da750483328529a29d889dedde