### PR TITLE
Fix VSCode ESLint working directory path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 // NOTE: VSCodeでは第一階層にtsconfig.jsonが存在しない時にエラーが出るため、参照ディレクトリを変更する。
 // @ref: https://zenn.dev/taichifukumoto/scraps/45be5ffdfa8457
 {
-  "eslint.workingDirectories": ["./frontend"]
+  "eslint.workingDirectories": ["./"]
 }


### PR DESCRIPTION
## Summary
- update ESLint working directory in `.vscode/settings.json`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521ac12a288332bffbb8391ce24585