### PR TITLE
Fix framework listing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## 技術スキル
 
 - **プログラミング/マークアップ言語**: HTML, JavaScript, TypeScript
-- **フレームワーク/ライブラリ**: React, Next.js, SCSS, Tailwind.css
+- **フレームワーク/ライブラリ**: React, Next.js, SCSS, Tailwind CSS
 - **ツール**: Git, Warp, Slack, Gather, Notion, Cursor, VSCode
 
 ## 連絡先情報とソーシャルメディア


### PR DESCRIPTION
## Summary
- update README to show "Tailwind CSS" correctly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521ada9dec8332912dcf84abff6817