### PR TITLE
Add Jest setup and basic component tests

### DIFF
--- a/__tests__/link-banner-wrapper.test.tsx
+++ b/__tests__/link-banner-wrapper.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { LinkBannerWrapper } from '@/app/(home)/_components';
+
+const props = {
+  href: '/test',
+  iconLink: '/icon.png',
+  iconAlt: 'test icon',
+  title: 'Sample Title',
+  description: 'Sample description',
+};
+
+describe('LinkBannerWrapper', () => {
+  it('renders link with correct href', () => {
+    render(<LinkBannerWrapper {...props} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', props.href);
+  });
+
+  it('renders image with provided alt text', () => {
+    render(<LinkBannerWrapper {...props} />);
+    const img = screen.getByAltText(props.iconAlt);
+    expect(img).toBeInTheDocument();
+  });
+
+  it('shows title and description', () => {
+    render(<LinkBannerWrapper {...props} />);
+    expect(screen.getByText(props.title)).toBeInTheDocument();
+    expect(screen.getByText(props.description)).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "clsx": "^2.0.0",
@@ -23,6 +24,11 @@
     "eslint-config-next": "14.0.4",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@types/jest": "^29.5.0",
+    "ts-jest": "^29.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up Jest with React Testing Library
- add a simple test for `LinkBannerWrapper`
- include Jest configuration and setup
- expose npm `test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521ae37594833293af9a74f0ff2db1