### PR TITLE
Add skeleton pages for profile, skill, product and contact

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { MainContentsWrapper } from "@/app/_components/wrapper/main-contents-wrapper";
+import { Heading } from "@/app/_components/elements/heading";
+import { Text } from "@/app/_components/elements/text";
+
+export const metadata: Metadata = {
+  title: "Mogy Portfolio | Contact",
+  description: "モギー（Mogy）へのお問い合わせページです。",
+  alternates: {
+    canonical: "/contact",
+  },
+};
+
+const Contact = () => {
+  return (
+    <MainContentsWrapper>
+      <Heading as="h1">Contact</Heading>
+      <Text variant="normal">お問い合わせはこちらから。</Text>
+    </MainContentsWrapper>
+  );
+};
+
+export default Contact;

--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { MainContentsWrapper } from "@/app/_components/wrapper/main-contents-wrapper";
+import { Heading } from "@/app/_components/elements/heading";
+import { Text } from "@/app/_components/elements/text";
+
+export const metadata: Metadata = {
+  title: "Mogy Portfolio | Product",
+  description: "モギー（Mogy）が関わったプロダクトの一覧ページです。",
+  alternates: {
+    canonical: "/product",
+  },
+};
+
+const Product = () => {
+  return (
+    <MainContentsWrapper>
+      <Heading as="h1">Product</Heading>
+      <Text variant="normal">プロダクト一覧を掲載します。</Text>
+    </MainContentsWrapper>
+  );
+};
+
+export default Product;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { MainContentsWrapper } from "@/app/_components/wrapper/main-contents-wrapper";
+import { Heading } from "@/app/_components/elements/heading";
+import { Text } from "@/app/_components/elements/text";
+
+export const metadata: Metadata = {
+  title: "Mogy Portfolio | Profile",
+  description: "モギー（Mogy）のプロフィールページです。",
+  alternates: {
+    canonical: "/profile",
+  },
+};
+
+const Profile = () => {
+  return (
+    <MainContentsWrapper>
+      <Heading as="h1">Profile</Heading>
+      <Text variant="normal">プロフィールページの内容です。</Text>
+    </MainContentsWrapper>
+  );
+};
+
+export default Profile;

--- a/app/skill/page.tsx
+++ b/app/skill/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { MainContentsWrapper } from "@/app/_components/wrapper/main-contents-wrapper";
+import { Heading } from "@/app/_components/elements/heading";
+import { Text } from "@/app/_components/elements/text";
+
+export const metadata: Metadata = {
+  title: "Mogy Portfolio | Skill",
+  description: "モギー（Mogy）のスキルセットを紹介するページです。",
+  alternates: {
+    canonical: "/skill",
+  },
+};
+
+const Skill = () => {
+  return (
+    <MainContentsWrapper>
+      <Heading as="h1">Skill</Heading>
+      <Text variant="normal">スキルセットの情報を掲載します。</Text>
+    </MainContentsWrapper>
+  );
+};
+
+export default Skill;


### PR DESCRIPTION
## Summary
- add pages under `/profile`, `/skill`, `/product`, `/contact`
- each page exports `metadata` with title and description
- home page already links to these routes

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521ea31c6c833297863dd16413d896