### PR TITLE
Add unit tests for shared components

### DIFF
--- a/__tests__/heading.test.tsx
+++ b/__tests__/heading.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { Heading } from '@/app/_components/elements/heading';
+
+describe('Heading', () => {
+  it('renders the correct heading level', () => {
+    render(<Heading as="h2">Test Heading</Heading>);
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toHaveTextContent('Test Heading');
+  });
+
+  it('applies variant style for h1', () => {
+    render(<Heading as="h1">Title</Heading>);
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveClass('text-3xl', 'font-bold', 'leading-normal');
+  });
+});

--- a/__tests__/image.test.tsx
+++ b/__tests__/image.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { Image } from '@/app/_components/elements/image';
+
+describe('Image', () => {
+  it('renders with given alt text', () => {
+    render(<Image src="/pic.png" alt="sample" width={50} height={50} />);
+    expect(screen.getByAltText('sample')).toBeInTheDocument();
+  });
+});

--- a/__tests__/main-contents-wrapper.test.tsx
+++ b/__tests__/main-contents-wrapper.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { MainContentsWrapper } from '@/app/_components/wrapper/main-contents-wrapper';
+
+describe('MainContentsWrapper', () => {
+  it('renders children', () => {
+    render(
+      <MainContentsWrapper>
+        <p>child content</p>
+      </MainContentsWrapper>
+    );
+    expect(screen.getByText('child content')).toBeInTheDocument();
+  });
+});

--- a/__tests__/text.test.tsx
+++ b/__tests__/text.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { Text } from '@/app/_components/elements/text';
+
+describe('Text', () => {
+  it('renders children', () => {
+    render(<Text variant="normal">sample text</Text>);
+    expect(screen.getByText('sample text')).toBeInTheDocument();
+  });
+
+  it('applies xl style', () => {
+    render(<Text variant="xl">big text</Text>);
+    const paragraph = screen.getByText('big text');
+    expect(paragraph).toHaveClass('text-xl', 'font-bold');
+  });
+});


### PR DESCRIPTION
## Summary
- cover heading, text, image and wrapper components with jest tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521eabe1588332931f64a3468ddb5c