### PR TITLE
Set default lang to Japanese

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ const NotoSansJp = Noto_Sans_JP({ subsets: ["latin"] });
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <html lang="en">
+    <html lang="ja">
       <body className={clsx(`bg-[#e0f7ff]`, NotoSansJp.className)}>
         {children}
       </body>


### PR DESCRIPTION
## Summary
- switch `<html lang>` to `ja` in `app/layout.tsx`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852215bd3b88332b0f8e88e67b4bb38