### PR TITLE
Extend Link component props

### DIFF
--- a/app/_components/elements/link/link.tsx
+++ b/app/_components/elements/link/link.tsx
@@ -1,12 +1,14 @@
-import NextLink from "next/link";
+import NextLink, { LinkProps } from "next/link";
+import type { ComponentPropsWithoutRef } from "react";
 
-type Props = {
-  href: string;
-  children: React.ReactNode;
-  target?: "_blank" | "_self" | "_parent" | "_top";
-};
+type Props = LinkProps & ComponentPropsWithoutRef<"a">;
 
-export const Link = ({ href, children, target = "_self", ...props }: Props) => {
+export const Link = ({
+  href,
+  children,
+  target = "_self",
+  ...props
+}: Props) => {
   const rel = target === "_blank" ? "noopener noreferrer" : undefined;
   return (
     <NextLink href={href} target={target} rel={rel} {...props}>


### PR DESCRIPTION
## Summary
- extend Link component to accept HTML attributes using `ComponentPropsWithoutRef` and `LinkProps`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852215c498c8332b7acd35ff52688aa