### PR TITLE
Enhance typography: responsive headings and expanded text variants

### DIFF
--- a/app/_components/elements/heading/heading.tsx
+++ b/app/_components/elements/heading/heading.tsx
@@ -8,12 +8,12 @@ type Props = ComponentProps<"h1"> & {
 };
 
 const variantStyle = {
-  h1: "text-3xl font-bold leading-normal",
-  h2: "",
-  h3: "",
-  h4: "",
-  h5: "",
-};
+    h1: "text-3xl md:text-4xl font-bold leading-tight",
+  h2: "text-2xl md:text-3xl font-bold leading-tight",
+  h3: "text-xl md:text-2xl font-semibold leading-snug",
+  h4: "text-lg md:text-xl font-semibold leading-snug",
+  h5: "text-base md:text-lg font-medium leading-normal",
+
 
 export const Heading = ({ as, children }: Props) => {
   const Component = as;

--- a/app/_components/elements/text/text.tsx
+++ b/app/_components/elements/text/text.tsx
@@ -1,16 +1,25 @@
 import { ReactNode } from "react";
 import { clsx } from "clsx";
 
-type Props = {
+// Define type for supported text variants
+export type TextVariant = "sm" | "normal" | "lg" | "xl" | "2xl";
+
+// Define component props with a variant (defaults to "normal" in the component)
+interface Props {
   children: ReactNode;
-  variant: "normal" | "xl";
-};
+  variant: TextVariant;
+}
 
-const variantStyle = {
+// Map each variant to Tailwind CSS classes for text sizing and weight
+const variantStyle: Record<TextVariant, string> = {
+  sm: "text-sm",
   normal: "text-base",
-  xl: "text-xl font-bold",
+  lg: "text-lg",
+  xl: "text-xl",
+  "2xl": "text-2xl font-semibold",
 };
 
-export const Text = ({ children, variant }: Props) => {
+// Text component renders a <p> element with classes based on the variant (default is "normal")
+export const Text = ({ children, variant = "normal" }: Props) => {
   return <p className={clsx(variantStyle[variant])}>{children}</p>;
 };


### PR DESCRIPTION
### 概要
Heading コンポーネントに h1〜h5 の各バリエーションを追加し、レスポンシブにフォントサイズが変化するように改善しました。Text コンポーネントには sm / normal / lg / xl / 2xl のバリエーションを追加し、デフォルトで normal を適用するようにしました。

### 実装・修正内容
- Heading コンポーネントに新たな variantStyle を追加し、各見出しレベル(h1〜h5)で適切なフォントサイズ・行間・ウェイトを設定しました。
- Text コンポーネントの variant を拡張し、5段階のテキストサイズと `font-semibold` を用いた強調を追加しました。

### 確認方法
ローカルで `npm run dev` を実行し、ページを閲覧して見出しと本文のサイズがデバイス幅に応じて適切に変化するかを確認してください。